### PR TITLE
Target Node.js 18, update dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,12 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 16
-          - 14
+          - 21
+          - 20
+          - 18
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import process from 'node:process';
 import meow from 'meow';
-import {includeKeys} from 'filter-obj';
+import {excludeKeys} from 'filter-obj';
 import packageJson from 'package-json';
 
 const cli = meow(`
@@ -27,6 +27,6 @@ if (!packageName) {
 }
 
 let package_ = await packageJson(packageName, {version});
-package_ = includeKeys(package_, key => key.at(0) !== '_' && key !== 'directories');
+package_ = excludeKeys(package_, key => key.startsWith('_') || key === 'directories');
 
 console.log(JSON.stringify(package_, undefined, '  '));

--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import process from 'node:process';
 import meow from 'meow';
-import filterObject from 'filter-obj';
+import {includeKeys} from 'filter-obj';
 import packageJson from 'package-json';
 
 const cli = meow(`
@@ -12,7 +12,7 @@ const cli = meow(`
 	  $ package-json ava
 	  {
 	    "name": "ava",
-	    "version": "0.18.0",
+	    "version": "6.1.1",
 	    …
 	  }
 `, {
@@ -27,6 +27,6 @@ if (!packageName) {
 }
 
 let package_ = await packageJson(packageName, {version});
-package_ = filterObject(package_, key => key[0] !== '_' && key !== 'directories');
+package_ = includeKeys(package_, key => key.at(0) !== '_' && key !== 'directories');
 
 console.log(JSON.stringify(package_, undefined, '  '));

--- a/cli.js
+++ b/cli.js
@@ -6,7 +6,7 @@ import packageJson from 'package-json';
 
 const cli = meow(`
 	Usage
-	  $ package-json <name> [version]
+	  $ package-json <name> [version=latest]
 
 	Example
 	  $ package-json ava

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 	"dependencies": {
 		"filter-obj": "^5.1.0",
 		"meow": "^13.2.0",
-		"package-json": "^9.0.0"
+		"package-json": "^10.0.0"
 	},
 	"devDependencies": {
 		"ava": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"package-json": "cli.js"
 	},
 	"engines": {
-		"node": ">=14.16"
+		"node": ">=18"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -37,13 +37,13 @@
 		"scoped"
 	],
 	"dependencies": {
-		"filter-obj": "^3.0.0",
-		"meow": "^10.1.2",
-		"package-json": "^8.0.0"
+		"filter-obj": "^5.1.0",
+		"meow": "^13.2.0",
+		"package-json": "^9.0.0"
 	},
 	"devDependencies": {
-		"ava": "^4.3.0",
-		"execa": "^6.1.0",
-		"xo": "^0.49.0"
+		"ava": "^6.1.1",
+		"execa": "^8.0.1",
+		"xo": "^0.57.0"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ npm install --global package-json-cli
 $ package-json --help
 
   Usage
-    $ package-json <name> [version]
+    $ package-json <name> [version=latest]
 
   Example
     $ package-json ava

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ $ package-json --help
     $ package-json ava
     {
       "name": "ava",
-      "version": "0.18.0"
+      "version": "6.1.1"
       …
     }
 ```

--- a/test.js
+++ b/test.js
@@ -3,5 +3,17 @@ import {execa} from 'execa';
 
 test('main', async t => {
 	const {stdout} = await execa('./cli.js', ['ava']);
-	t.is(JSON.parse(stdout).name, 'ava');
+
+	t.like(JSON.parse(stdout), {
+		name: 'ava',
+	});
+});
+
+test('can specify a version', async t => {
+	const {stdout} = await execa('./cli.js', ['ava', '6.0.0']);
+
+	t.like(JSON.parse(stdout), {
+		name: 'ava',
+		version: '6.0.0',
+	});
 });

--- a/test.js
+++ b/test.js
@@ -15,5 +15,6 @@ test('can specify a version', async t => {
 	t.like(JSON.parse(stdout), {
 		name: 'ava',
 		version: '6.0.0',
+		versions: undefined,
 	});
 });

--- a/test.js
+++ b/test.js
@@ -6,6 +6,7 @@ test('main', async t => {
 
 	t.like(JSON.parse(stdout), {
 		name: 'ava',
+		versions: undefined, // 'latest' by default
 	});
 });
 


### PR DESCRIPTION
Updates dependencies and tests. With the update to `package-json`, this now returns the latest version of a package if no version is specified, so I updated the help text:

```
Usage
  $ package-json <name> [version=latest]
```