### PR TITLE
Gracefully handle `package-json` errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 	],
 	"dependencies": {
 		"filter-obj": "^5.1.0",
+		"log-symbols": "^6.0.0",
 		"meow": "^13.2.0",
 		"package-json": "^10.0.0"
 	},


### PR DESCRIPTION
```sh
$ package-json nnnope
✖ Package `nnnope` does not exist.
```

```sh
$ package-json ava 0.0.0
✖ Could not find version `0.0.0` of the package `ava`.
```

---

This is my last PR.